### PR TITLE
change osu-wine to steam-wine

### DIFF
--- a/steam-wine.conf
+++ b/steam-wine.conf
@@ -1,6 +1,6 @@
 ################################################################################
-# Config for osu-wine run script
-# Original: https://github.com/Nefelim4ag/osu-wine
+# Config for steam-wine run script
+# Original: https://github.com/Nefelim4ag/steam-wine
 # This is a default values, change it if needed
 ################################################################################
 


### PR DESCRIPTION
I suppose this should be "steam-wine" instead of "osu-wine" in the steam-wine.conf file.